### PR TITLE
chore(build): add support for musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,76 @@ jobs:
         run: |
           php -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext }}" \
             vendor/bin/phpunit
+
+  build-musl:
+    name: PHP ${{ matrix.php }}-nts (linux-x86_64-musl)
+    needs: checks
+    runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-cli-alpine
+    defaults:
+      run:
+        shell: sh
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+
+    env:
+      LIBCLANG_PATH: /usr/lib/llvm16/lib
+
+    steps:
+      - name: Install Alpine dependencies
+        run: |
+          apk add --no-cache \
+            bash \
+            build-base \
+            clang16-libclang \
+            curl \
+            git \
+            libxml2-dev \
+            linux-headers \
+            oniguruma-dev \
+            openssl
+          docker-php-ext-install dom mbstring xml xmlwriter
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: musl-php${{ matrix.php }}-nts
+
+      - name: Install Composer
+        run: |
+          curl -sS https://getcomposer.org/installer -o composer-setup.php
+          php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          rm composer-setup.php
+
+      - name: Verify PHP thread safety
+        run: |
+          actual=$(php -r "echo PHP_ZTS ? 'ts' : 'nts';")
+          if [ "nts" != "$actual" ]; then
+            echo "::error::Expected PHP nts but got $actual"
+            exit 1
+          fi
+
+      - name: Build extension
+        run: cargo build --release
+
+      - name: Inspect linked libraries
+        run: ldd target/release/libext_typst.so || true
+
+      - name: Verify extension loads
+        run: |
+          php -d "extension=$GITHUB_WORKSPACE/target/release/libext_typst.so" \
+            -r "var_dump(extension_loaded('typst'));"
+
+      - name: Install Composer dependencies
+        run: composer update --no-interaction --prefer-dist --ignore-platform-req=ext-typst
+
+      - name: Run PHPUnit
+        run: |
+          php -d "extension=$GITHUB_WORKSPACE/target/release/libext_typst.so" \
+            vendor/bin/phpunit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,120 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-musl:
+    name: PHP ${{ matrix.php }}-nts (linux-x86_64-musl)
+    runs-on: ubuntu-latest
+    needs: [metadata, create-release]
+    if: always() && needs.metadata.result == 'success' && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+    container:
+      image: php:${{ matrix.php }}-cli-alpine
+    defaults:
+      run:
+        shell: sh
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+
+    env:
+      LIBCLANG_PATH: /usr/lib/llvm16/lib
+
+    steps:
+      - name: Install Alpine dependencies
+        run: |
+          apk add --no-cache \
+            bash \
+            build-base \
+            clang16-libclang \
+            curl \
+            git \
+            github-cli \
+            libxml2-dev \
+            linux-headers \
+            oniguruma-dev \
+            openssl \
+            zip
+          docker-php-ext-install dom mbstring xml xmlwriter
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-musl-php${{ matrix.php }}-nts
+
+      - name: Install Composer
+        run: |
+          curl -sS https://getcomposer.org/installer -o composer-setup.php
+          php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          rm composer-setup.php
+
+      - name: Verify PHP thread safety
+        run: |
+          actual=$(php -r "echo PHP_ZTS ? 'ts' : 'nts';")
+          if [ "nts" != "$actual" ]; then
+            echo "::error::Expected PHP nts but got $actual"
+            exit 1
+          fi
+
+      - name: Build extension
+        run: cargo build --release
+
+      - name: Inspect linked libraries
+        run: ldd target/release/libext_typst.so || true
+
+      - name: Verify extension loads
+        run: |
+          php -d "extension=$GITHUB_WORKSPACE/target/release/libext_typst.so" \
+            -r "var_dump(extension_loaded('typst'));"
+
+      - name: Install Composer dependencies
+        run: composer update --no-interaction --prefer-dist --ignore-platform-req=ext-typst
+
+      - name: Run PHPUnit
+        run: |
+          php -d "extension=$GITHUB_WORKSPACE/target/release/libext_typst.so" \
+            vendor/bin/phpunit
+
+      - name: Package binary
+        id: package
+        run: |
+          VERSION="${{ needs.metadata.outputs.version }}"
+          PKG_NAME="php_typst-${VERSION}_php${{ matrix.php }}-x86_64-linux-musl"
+          STAGING="_release/${PKG_NAME}"
+          mkdir -p "${STAGING}"
+
+          cp "target/release/libext_typst.so" "${STAGING}/typst.so"
+
+          cd _release
+          zip -r "${PKG_NAME}.zip" "${PKG_NAME}"
+          cd ..
+
+          echo "PKG_NAME=${PKG_NAME}.zip" >> "$GITHUB_OUTPUT"
+          echo "PKG_PATH=_release/${PKG_NAME}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.package.outputs.PKG_PATH }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.PKG_NAME }}
+          path: ${{ steps.package.outputs.PKG_PATH }}
+
+      - name: Upload to release
+        if: needs.metadata.outputs.is-release == 'true'
+        run: gh release upload "${{ github.ref_name }}" "${{ steps.package.outputs.PKG_PATH }}" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [metadata, build]
+    needs: [metadata, build, build-musl]
     if: needs.metadata.outputs.is-release == 'true'
     steps:
       - uses: actions/checkout@v4

--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,15 @@ build:
 release:
     cargo build --release
 
+# Build the extension in an Alpine Linux musl container
+release-musl php_version="8.4":
+    docker run --rm -v "$PWD:/app" -w /app php:{{php_version}}-cli-alpine sh -lc '
+      apk add --no-cache bash build-base clang16-libclang curl git linux-headers openssl &&
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal &&
+      . "$HOME/.cargo/env" &&
+      LIBCLANG_PATH=/usr/lib/llvm16/lib cargo build --release
+    '
+
 # Run all tests
 test: build
     php -d extension={{ext_debug}} vendor/bin/phpunit


### PR DESCRIPTION
There is a bit of duplication on the job because `ubuntu-latest` is not a `musl` environment, so I need a separate job to run inside an alpine container. 

However, if you don't like the duplication, what I can do is to change the main `build` job to build in a docker image, and conditionally select images based on the `libc` flavour we want on the matrix, like `ext-grpc-rs` does in their [workflow](https://github.com/BSN4/grpc-php-rs/blob/main/.github/workflows/release.yml). I'd be touching a job that works well already though, and that's why I went with the separate job approach.

What do you think?

Closes #5 