### PR TITLE
fix: register PHP module as 'typst' to match extension-name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,9 @@ jobs:
 
       - name: Verify extension loads
         run: |
-          php -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext }}" \
-            -r "var_dump(extension_loaded('typst'));"
+          php -d display_startup_errors=1 \
+            -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext }}" \
+            -r "exit(extension_loaded('typst') ? 0 : 1);"
 
       - name: Install Composer dependencies
         run: composer update --no-interaction --prefer-dist --ignore-platform-req=ext-typst

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,8 @@ jobs:
 
       - name: Verify extension loads
         run: |
-          php -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext-file }}" \
+          php -d display_startup_errors=1 \
+            -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext-file }}" \
             -r "exit(extension_loaded('typst') ? 0 : 1);"
 
       - name: Install Composer dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Verify extension loads
         run: |
           php -d "extension=$GITHUB_WORKSPACE/target/release/${{ matrix.ext-file }}" \
-            -r "var_dump(extension_loaded('typst'));"
+            -r "exit(extension_loaded('typst') ? 0 : 1);"
 
       - name: Install Composer dependencies
         run: composer update --no-interaction --prefer-dist --ignore-platform-req=ext-typst

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub fn typst_engine_version() -> &'static str {
 #[php(startup = startup)]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        .name("typst")
         .interface::<extension::error::PhpInterfaceExceptionInterface>()
         .class::<extension::error::RuntimeException>()
         .class::<extension::error::LogicException>()

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -26,6 +26,12 @@ use Typst\World;
 
 final class ReflectionTest extends TestCase
 {
+    public function testExtensionIsRegisteredAsTypst(): void
+    {
+        static::assertTrue(extension_loaded('typst'));
+        static::assertContains('typst', get_loaded_extensions());
+    }
+
     public function testCompilerIsFinal(): void
     {
         $r = new \ReflectionClass(Compiler::class);


### PR DESCRIPTION
## Problem

`pie install carthage-software/ext-typst` installs the binary but the extension does not get enabled (#3).

## Root cause

PIE enables an extension by writing `extension=typst` to an ini file and then verifying that a module named exactly `typst` (the `extension-name` from composer.json) shows up in `php -m`. When that check fails, PIE silently rolls back the ini change and reports the extension was not automatically enabled.

The module failed that check: ext-php-rs defaults the module name to the crate name, so the extension registered as `ext-typst` instead of `typst`.

This went unnoticed because the release workflow's "Verify extension loads" step ran `var_dump(extension_loaded('typst'));` — printing `bool(false)` on every release build without ever failing.

## Changes

- Override the module name to `typst` via `ModuleBuilder::name()` in `src/lib.rs`
- Add a regression test asserting `extension_loaded('typst')`
- Make the release workflow's load check actually exit non-zero on failure

Fixes #3