### PR TITLE
chore: remove obsolete mago-expect pragmas

### DIFF
--- a/tests/PendingDocumentTest.php
+++ b/tests/PendingDocumentTest.php
@@ -70,7 +70,7 @@ final class PendingDocumentTest extends TestCase
         $pending = $this->compiler->compileInBackground($source);
         $stream = $pending->getNotificationStream();
 
-        static::assertIsResource($stream); // @mago-expect analysis:redundant-type-comparison - runtime check
+        static::assertIsResource($stream);
     }
 
     public function testGetNotificationStreamAfterJoinThrowsLogicException(): void
@@ -240,8 +240,8 @@ final class PendingDocumentTest extends TestCase
         $stream1 = $pending->getNotificationStream();
         $stream2 = $pending->getNotificationStream();
 
-        static::assertIsResource($stream1); // @mago-expect analysis:redundant-type-comparison - runtime check.
-        static::assertIsResource($stream2); // @mago-expect analysis:redundant-type-comparison - runtime check.
+        static::assertIsResource($stream1);
+        static::assertIsResource($stream2);
 
         $pending->join();
     }

--- a/tests/WorldTest.php
+++ b/tests/WorldTest.php
@@ -12,9 +12,6 @@ use Typst\Inspector;
 use Typst\Source;
 use Typst\World;
 
-/**
- * @mago-expect analysis:redundant-type-comparison - runtime checks, verifying API
- */
 final class WorldTest extends TestCase
 {
     public function testDefaultConstruction(): void


### PR DESCRIPTION
Mago no longer reports `redundant-type-comparison` for these `assertIsResource()` calls, so the `@mago-expect` suppressions now warn as unfulfilled on every CI run.

Removes the three stale pragmas in `PendingDocumentTest` and `WorldTest`. No behavior change — the assertions themselves are untouched.